### PR TITLE
Add README with Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Stock Analyzer
+
+Stock Analyzer is a web application for analyzing Yahoo Finance data. The project provides a FastAPI backend, a Streamlit frontend and a MongoDB database.
+
+## Getting Started
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [docker compose](https://docs.docker.com/compose/)
+- An OpenAI API key (required for NLP features)
+
+### Running with Docker
+
+1. Clone this repository.
+2. Provide your OpenAI key by exporting the environment variable `OPENAI_API_KEY` or by creating a `.env` file in the project root containing it.
+3. Build and start the containers:
+
+```bash
+docker compose up --build
+```
+
+4. Open the Streamlit frontend at [http://localhost:8501](http://localhost:8501).
+5. The FastAPI backend will be available at [http://localhost:8000](http://localhost:8000).
+
+### Makefile Commands
+
+For convenience the repository contains a `Makefile` with common commands:
+
+```bash
+make up        # build and start containers
+make down      # stop containers
+make restart   # rebuild and restart containers
+make logs      # follow container logs
+make clean_all # remove all containers, images and volumes
+```
+
+## Project Structure
+
+- `backend/` - FastAPI application
+- `frontend/` - Streamlit dashboard
+- `mongodb/` - MongoDB configuration
+- `docker-compose.yaml` - Compose configuration
+- `Makefile` - helper commands
+


### PR DESCRIPTION
## Summary
- add an English README file describing the project
- include docker compose usage and Makefile helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684b6b6875f48329a7fd7b45bd265348